### PR TITLE
[Docs] Update text typo

### DIFF
--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -3,13 +3,13 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
-import { EuiCallOut } from '../../../../src';
 
 import {
   EuiLink,
   EuiCode,
   EuiComboBox,
   EuiText,
+  EuiCallOut,
 } from '../../../../src/components';
 
 import { EuiComboBoxOptionOption } from '!!prop-loader!../../../../src/components/combo_box/types';
@@ -245,31 +245,36 @@ const labelledbySnippet = `<EuiComboBox
 export const ComboBoxExample = {
   title: 'Combo box',
   intro: (
-    <>
-      <EuiText>
-        <p>
-          Use a <strong>EuiComboBox</strong> when the input has so many options
-          that the user needs to be able to search them, the user needs to be
-          able to select multiple options, and/or the user should have the
-          ability to specify a custom value in addition to selecting from a
-          predetermined list.
-        </p>
-        <EuiCallOut
-          iconType="accessibility"
-          title={
-            <>
-              You must add an accessible label to each instance of{' '}
-              <strong>EuiComboBox</strong>
-            </>
-          }
+    <EuiText>
+      <p>
+        Use a <strong>EuiComboBox</strong> when the input has so many options
+        that the user needs to be able to search them, the user needs to be able
+        to select multiple options, and/or the user should have the ability to
+        specify a custom value in addition to selecting from a predetermined
+        list. If you're unsure of which selection component to use, see{' '}
+        <EuiLink
+          href="https://github.com/elastic/eui/discussions/7049"
+          target="_blank"
         >
-          Labels can be created by wrapping the combo box in an{' '}
-          <strong>EuiFormRow</strong> with a <EuiCode>label</EuiCode>, adding an{' '}
-          <EuiCode>aria-label</EuiCode> prop, or passing a text node ID to the{' '}
-          <EuiCode>aria-labelledby</EuiCode> prop.
-        </EuiCallOut>
-      </EuiText>
-    </>
+          EUI's in-depth guide to selection components
+        </EuiLink>{' '}
+        for more information.
+      </p>
+      <EuiCallOut
+        iconType="accessibility"
+        title={
+          <>
+            You must add an accessible label to each instance of{' '}
+            <strong>EuiComboBox</strong>
+          </>
+        }
+      >
+        Labels can be created by wrapping the combo box in an{' '}
+        <strong>EuiFormRow</strong> with a <EuiCode>label</EuiCode>, adding an{' '}
+        <EuiCode>aria-label</EuiCode> prop, or passing a text node ID to the{' '}
+        <EuiCode>aria-labelledby</EuiCode> prop.
+      </EuiCallOut>
+    </EuiText>
   ),
   sections: [
     {

--- a/src-docs/src/views/date_picker/range.tsx
+++ b/src-docs/src/views/date_picker/range.tsx
@@ -10,7 +10,7 @@ export default () => {
 
   return (
     /* DisplayToggles wrapper for Docs only */
-    <DisplayToggles canCompressed={false} canPrepend={true} canAppend={true}>
+    <DisplayToggles canPrepend={true} canAppend={true}>
       <EuiDatePickerRange
         startDateControl={
           <EuiDatePicker

--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -321,17 +321,15 @@ export const FormControlsExample = {
             .
           </p>
           <p>
-            If you need more customization for how the options and/or selected
-            values render, you can use an{' '}
-            <Link to="/forms/super-select">
-              <strong>EuiSuperSelect</strong>
-            </Link>{' '}
-            instead. For long lists of options use an{' '}
-            <Link to="/forms/combo-box">
-              <strong>EuiComboBox</strong>
-            </Link>
-            , which has search and multi-select capabilities, but also has
-            restrictions on how items are rendered.
+            If you need more customization for searching or rendering options,
+            see{' '}
+            <EuiLink
+              href="https://github.com/elastic/eui/discussions/7049"
+              target="_blank"
+            >
+              EUI's guide on selection components
+            </EuiLink>{' '}
+            .
           </p>
         </>
       ),

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -9,6 +9,7 @@ import {
   EuiSelectableMessage,
   EuiText,
   EuiCallOut,
+  EuiLink,
 } from '../../../../src';
 
 import {
@@ -69,7 +70,14 @@ export const SelectableExample = {
         </strong>{' '}
         but can be used to simplify the construction of popover navigational
         menus; i.e. the spaces menu in the{' '}
-        <Link to="/layout/header">header</Link>.
+        <Link to="/layout/header">header</Link>. See{' '}
+        <EuiLink
+          href="https://github.com/elastic/eui/discussions/7049"
+          target="_blank"
+        >
+          EUI's in-depth guide on which selection component to use{' '}
+        </EuiLink>{' '}
+        for more information.
       </p>
     </EuiText>
   ),

--- a/src-docs/src/views/super_select/super_select_example.js
+++ b/src-docs/src/views/super_select/super_select_example.js
@@ -2,7 +2,12 @@ import React from 'react';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiSuperSelect } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiSuperSelect,
+  EuiLink,
+  EuiCallOut,
+} from '../../../../src/components';
 
 import SuperSelectBasic from './super_select_basic';
 const superSelectBasicSource = require('!!raw-loader!./super_select_basic');
@@ -54,6 +59,23 @@ const superSelectStatesSnippet = `<EuiSuperSelect
 
 export const SuperSelectExample = {
   title: 'Super select',
+  intro: (
+    <EuiCallOut
+      iconType="questionInCircle"
+      title="Not sure which selection component to use?"
+    >
+      <p>
+        See{' '}
+        <EuiLink
+          href="https://github.com/elastic/eui/discussions/7049"
+          target="_blank"
+        >
+          EUI's in-depth guide to selection components{' '}
+        </EuiLink>{' '}
+        for more information.
+      </p>
+    </EuiCallOut>
+  ),
   sections: [
     {
       source: [

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -75,6 +75,79 @@ exports[`EuiDatePickerRange is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiDatePickerRange props compressed 1`] = `
+<span
+  class="euiDatePickerRange emotion-euiDatePickerRange"
+>
+  <div
+    class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayoutDelimited"
+  >
+    <div
+      class="euiFormControlLayout__childrenWrapper"
+    >
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--static"
+      >
+        <span
+          class="euiFormControlLayoutCustomIcon"
+        >
+          <span
+            aria-hidden="true"
+            class="euiFormControlLayoutCustomIcon__icon"
+            data-euiicon-type="calendar"
+          />
+        </span>
+      </div>
+      <div
+        class="euiPopover emotion-euiPopover"
+      >
+        <div
+          class="euiPopover__anchor css-zih94u-render"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              aria-label="Press the down key to open a popover containing a calendar."
+              class="euiDatePicker euiFieldText euiDatePickerRange__start euiFormControlLayoutDelimited__input"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiText euiFormControlLayoutDelimited__delimiter emotion-euiText-s-euiTextColor-subdued"
+      >
+        <span
+          data-euiicon-type="sortRight"
+        >
+          to
+        </span>
+      </div>
+      <div
+        class="euiPopover emotion-euiPopover"
+      >
+        <div
+          class="euiPopover__anchor css-zih94u-render"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              aria-label="Press the down key to open a popover containing a calendar."
+              class="euiDatePicker euiFieldText euiDatePickerRange__end euiFormControlLayoutDelimited__input"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
 exports[`EuiDatePickerRange props disabled 1`] = `
 <span
   class="euiDatePickerRange emotion-euiDatePickerRange"

--- a/src/components/date_picker/date_picker_range.test.tsx
+++ b/src/components/date_picker/date_picker_range.test.tsx
@@ -41,6 +41,18 @@ describe('EuiDatePickerRange', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    test('compressed', () => {
+      const { container } = render(
+        <EuiDatePickerRange
+          startDateControl={<EuiDatePicker />}
+          endDateControl={<EuiDatePicker />}
+          compressed
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
     test('readOnly', () => {
       const { container } = render(
         <EuiDatePickerRange

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -35,7 +35,13 @@ import { EuiDatePickerProps } from './date_picker';
 export type EuiDatePickerRangeProps = CommonProps &
   Pick<
     EuiFormControlLayoutDelimitedProps,
-    'isLoading' | 'isInvalid' | 'readOnly' | 'fullWidth' | 'prepend' | 'append'
+    | 'isLoading'
+    | 'isInvalid'
+    | 'readOnly'
+    | 'fullWidth'
+    | 'compressed'
+    | 'prepend'
+    | 'append'
   > & {
     /**
      * Including any children will replace all innards with the provided children
@@ -100,6 +106,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   inline,
   shadow = true,
   fullWidth: _fullWidth,
+  compressed: _compressed,
   isCustom,
   readOnly,
   isLoading,
@@ -111,8 +118,9 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   prepend,
   ...rest
 }) => {
-  // `fullWidth` should not affect inline datepickers (matches non-range behavior)
+  // `fullWidth` and `compressed` should not affect inline datepickers (matches non-range behavior)
   const fullWidth = _fullWidth && !inline;
+  const compressed = _compressed && !inline;
 
   const classes = classNames('euiDatePickerRange', className);
 
@@ -206,6 +214,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
         startControl={startControl}
         endControl={endControl}
         fullWidth={fullWidth}
+        compressed={compressed}
         readOnly={readOnly}
         isDisabled={disabled}
         isInvalid={isInvalid}

--- a/upcoming_changelogs/7058.md
+++ b/upcoming_changelogs/7058.md
@@ -1,0 +1,5 @@
+- Updated `EuiDatePickerRange` to support `compressed` display
+
+**Bug fixes**
+
+- Fixed `EuiSuperDatePicker`'s `compressed` display

--- a/wiki/contributing-to-eui/developing/writing-styles-with-emotion.md
+++ b/wiki/contributing-to-eui/developing/writing-styles-with-emotion.md
@@ -1,7 +1,7 @@
 # Writing styles with Emotion
 
 EUI uses [`Emotion`](https://emotion.sh/) when writing CSS-in-JS styles.
-A general knowledge of writing CSS is enough in most cases, but there are some JavaScript-related differences that can result in unintended output. Similarly, there are feaures that don't exist in CSS of which we like to take advantage.
+A general knowledge of writing CSS is enough in most cases, but there are some JavaScript-related differences that can result in unintended output. Similarly, there are features that don't exist in CSS of which we like to take advantage.
 
 ## File patterns
 


### PR DESCRIPTION
## Summary
Fixed typo in docs text. 


### General checklist

~~[ ] Checked in both **light and dark** modes~~ 
~~[ ] Checked in **mobile**~~
~~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
~~[ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
~~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
~~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
~~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~~
~~[ ] Checked for **breaking changes** and labeled appropriately~~
~~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
~~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~~
